### PR TITLE
`rect` needs to be integers

### DIFF
--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -271,8 +271,8 @@ export const buildRect = (
   return [
     Math.round(crop.left * dimensions.width),
     Math.round(crop.top * dimensions.height),
-    width,
-    height,
+    Math.round(width),
+    Math.round(height),
   ].join(",")
 }
 


### PR DESCRIPTION
Added Math.round to make sure we provide integers to the Sanity API.