### PR TITLE
fix: add types export to package.json for TypeScript resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
This commit adds an explicit export for the TypeScript type definitions in the package.json file. It ensures that the types are correctly resolved by TypeScript in environments that adhere to the strict module resolution rules defined by the package's exports field. By including the "types" condition within the "." export, TypeScript tooling can now properly locate the index.d.ts file when the sanity-image package is imported.