### PR TITLE
Fix: compensate correctly for crops from the left/top

### DIFF
--- a/src/urlBuilder.test.ts
+++ b/src/urlBuilder.test.ts
@@ -405,6 +405,34 @@ describe("buildQueryParams", () => {
         q: 75,
         auto: "format",
       })
+
+      expect(
+        buildQueryParams({
+          id: image.asset._id,
+          crop: {
+            top: 0.5,
+            bottom: 0,
+            left: 0.5,
+            right: 0,
+          },
+          width: 375,
+          height: 100,
+          mode: "cover",
+          hotspot: {
+            x: 0.5,
+            y: 0.5,
+          },
+        })
+      ).toEqual(<ImageQueryParams>{
+        rect: "500,500,500,500",
+        "fp-x": 0,
+        "fp-y": 0,
+        w: 375,
+        h: 100,
+        fit: "crop",
+        q: 75,
+        auto: "format",
+      })
     })
 
     it("tolerates out-of-bounds focal points", () => {

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -207,8 +207,12 @@ export const buildQueryParams = ({
     if (hotspot) {
       // Hotspot is relative to post-`rect` dimensions; if `crop` is present,
       // the hotspot inputs need to be adjusted accordingly
-      const x = crop ? hotspot.x / (1 - crop.left - crop.right) : hotspot.x
-      const y = crop ? hotspot.y / (1 - crop.top - crop.bottom) : hotspot.y
+      const x = crop
+        ? (hotspot.x - crop.left) / (1 - crop.left - crop.right)
+        : hotspot.x
+      const y = crop
+        ? (hotspot.y - crop.top) / (1 - crop.top - crop.bottom)
+        : hotspot.y
 
       params["fp-x"] = roundWithPrecision(clamp(x, 0, 1), 3)
       params["fp-y"] = roundWithPrecision(clamp(y, 0, 1), 3)


### PR DESCRIPTION
Hi @coreyward, I found this bug when trying to apply hotspots to images with crop applied on the top and left sides, as you can see in the image below it fails to focus properly. After some calculations and analysis of the code I found the bug and fixed it, it was just lacking the `- crop.left` or `- crop.top` in the first part of the calculation.

I also added a test that was failing before and now passes.

It would be awesome to have this fix make it into a patch version, as I'm having trouble trying to use this fix by depending on my repository (the folder in node_modules ends up without a dist folder).

**Before**
![2024-10-04_18-32](https://github.com/user-attachments/assets/c366bc07-d07c-4de5-8d43-0ff3da93654b)

**After**
![2024-10-04_23-43](https://github.com/user-attachments/assets/024bf986-1559-40b5-ab29-993469791280)
