### PR TITLE
Add a small callout to the README that Next.js implementations with `preview` will need to specify client-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,18 @@ export const Image = (
 ) => <SanityImage baseUrl={baseUrl} {...props} />
 ```
 
+<details>
+  <summary>⚠️ Next.js components using `preview` will need to `"use client";`</summary>
+
+When using `SanityImage` in a Next.js (14 or newer) application, when you provide a `preview` string, your Image component will be required to spicify that it is a client-only component, which is done by adding the following line to the top of the compoent’s file:
+
+```
+"use client";
+
+```
+
+</details>
+
 ### Styling your images
 
 I recommend setting something like the following CSS for images in your project,

--- a/README.md
+++ b/README.md
@@ -244,13 +244,12 @@ export const Image = (
 ```
 
 <details>
-  <summary>⚠️ Next.js components using `preview` will need to `"use client";`</summary>
+  <summary><strong>⚠️ Next.js components using `preview` will need to "use client"</strong></summary>
 
 When using `SanityImage` in a Next.js (14 or newer) application, when you provide a `preview` string, your Image component will be required to spicify that it is a client-only component, which is done by adding the following line to the top of the compoent’s file:
 
 ```
 "use client";
-
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ export const Image = (
 <details>
   <summary><strong>⚠️ Next.js components using `preview` will need to "use client"</strong></summary>
 
-When using `SanityImage` in a Next.js (14 or newer) application, when you provide a `preview` string, your Image component will be required to spicify that it is a client-only component, which is done by adding the following line to the top of the compoent’s file:
+When using `SanityImage` in a Next.js (14 or newer) application, if you provide a `preview` string, your Image component will be required to specify that it is a client-only component, which is done by adding the following line to the top of the compoent’s file:
 
 ```
 "use client";


### PR DESCRIPTION
Just a small, hopefully helpful clarification for those using this component in a Next.js context.