### PR TITLE
loosen hotspot & crop types to match sanity typegen

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,15 +68,15 @@ export type ImageWithPreviewProps<T extends React.ElementType> = {
   React.ComponentPropsWithRef<T>
 
 export type CropData = {
-  bottom: number
-  left: number
-  right: number
-  top: number
+  top?: number
+  bottom?: number
+  left?: number
+  right?: number
 }
 
 export type HotspotData = {
-  x: number
-  y: number
+  x?: number
+  y?: number
 }
 
 export type Asset = {
@@ -165,7 +165,7 @@ export type ImageQueryInputs = {
    * The hotspot coordinates to use for the image. Note: hotspot `width` and
    * `height` are not used.
    */
-  hotspot?: { x: number; y: number }
+  hotspot?: HotspotData
 
   /** The crop coordinates to use for the image. */
   crop?: CropData

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -208,11 +208,13 @@ export const buildQueryParams = ({
       // Hotspot is relative to post-`rect` dimensions; if `crop` is present,
       // the hotspot inputs need to be adjusted accordingly
       const x = crop
-        ? (hotspot.x - crop.left) / (1 - crop.left - crop.right)
-        : hotspot.x
+        ? ((hotspot.x ?? 0) - (crop.left ?? 0)) /
+          (1 - (crop.left ?? 0) - (crop.right ?? 0))
+        : hotspot.x ?? 0
       const y = crop
-        ? (hotspot.y - crop.top) / (1 - crop.top - crop.bottom)
-        : hotspot.y
+        ? ((hotspot.y ?? 0) - (crop.top ?? 0)) /
+          (1 - (crop.top ?? 0) - (crop.bottom ?? 0))
+        : hotspot.y ?? 0
 
       params["fp-x"] = roundWithPrecision(clamp(x, 0, 1), 3)
       params["fp-y"] = roundWithPrecision(clamp(y, 0, 1), 3)
@@ -252,14 +254,21 @@ export const croppedImageSize = (
   dimensions: { width: number; height: number },
   crop: CropData
 ): ImageIdParts["dimensions"] => {
-  if (crop.left + crop.right >= 1 || crop.top + crop.bottom >= 1) {
+  if (
+    (crop.left ?? 0) + (crop.right ?? 0) >= 1 ||
+    (crop.top ?? 0) + (crop.bottom ?? 0) >= 1
+  ) {
     throw new Error(
       `Invalid crop: ${JSON.stringify(crop)}; crop values must be less than 1`
     )
   }
 
-  const width = Math.round(dimensions.width * (1 - crop.left - crop.right))
-  const height = Math.round(dimensions.height * (1 - crop.top - crop.bottom))
+  const width = Math.round(
+    dimensions.width * (1 - (crop.left ?? 0) - (crop.right ?? 0))
+  )
+  const height = Math.round(
+    dimensions.height * (1 - (crop.top ?? 0) - (crop.bottom ?? 0))
+  )
   const aspectRatio = width / height
 
   return { width, height, aspectRatio }
@@ -276,8 +285,8 @@ export const buildRect = (
   const { width, height } = croppedImageSize(dimensions, crop)
 
   return [
-    Math.round(crop.left * dimensions.width),
-    Math.round(crop.top * dimensions.height),
+    Math.round((crop.left ?? 0) * dimensions.width),
+    Math.round((crop.top ?? 0) * dimensions.height),
     width,
     height,
   ].join(",")


### PR DESCRIPTION
[Sanity typegen](https://www.sanity.io/docs/sanity-typegen) spits out types that look like this:

```typescript
export type SanityImageCrop = {
  _type: "sanity.imageCrop"
  top?: number
  bottom?: number
  left?: number
  right?: number
}

export type SanityImageHotspot = {
  _type: "sanity.imageHotspot"
  x?: number
  y?: number
  height?: number
  width?: number
}
```

with the current type these can't be used directly - you need to do a little typecheck dance:
```typescript
<SanityImage
  // check & provide fallbacks
  hotspot={
    src.hotspot
      ? { x: src.hotspot.x ?? 0, y: src.hotspot.y ?? 0 }
      : undefined
  }
  // or check each property individually
  crop={
    src.crop?.top && src.crop.left && src.crop.bottom && src.crop.right
      ? {
          top: src.crop.top,
          left: src.crop.left,
          bottom: src.crop.bottom,
          right: src.crop.right,
        }
      : undefined
  }
/>
```

this would loosen the type to allow usage like this:
```typescript
<SanityImage
  hotspot={src.hotspot}
  crop={src.crop}
/>
```

I don't think sanity would ever spit out an image with a partially defined crop or hotspot value, but I've also added fallbacks where needed to prevent runtime errors if they did