### PR TITLE
Add support for vanity names

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ comfortable with TypeScript, that might give you more detail.
   the Sanity Image API. See the
   [Sanity Image API documentation](https://www.sanity.io/docs/image-urls) for a
   list of available options.
+- `vanityName` (string) - Optional -  filename to append to the image URL.
+  Sometimes useful for SEO purposes.
 
 That's the gist. There's a ton more in the inline comments and types and such,
 and I'll add more details as I think of them. Feel free to open an issue or

--- a/src/SanityImage.test.tsx
+++ b/src/SanityImage.test.tsx
@@ -280,6 +280,33 @@ describe("svg source image", () => {
   })
 })
 
+describe('vanity name', () => {
+  describe('when provided vanityName prop', () => {
+    it('appends vanity name to src and srcset URLs', () => {
+      const vanityName = 'custom-name'
+
+      const { baseElement } = render(
+        <SanityImage
+          id={id}
+          baseUrl={baseUrl}
+          vanityName={vanityName}
+          width={500}
+        />
+      )
+
+      const { src, srcset } = getAttributes(baseElement)
+
+      expect(src).toEqual(
+        `/images/abc123-1000x1000.jpg/${vanityName}?auto=format&fit=max&q=75&w=500`
+      )
+
+      expect(srcset).toEqual(
+        `/images/abc123-1000x1000.jpg/${vanityName}?auto=format&fit=max&q=75&w=250 250w, /images/abc123-1000x1000.jpg/${vanityName}?auto=format&fit=max&q=75&w=500 500w, /images/abc123-1000x1000.jpg/${vanityName}?auto=format&fit=max&q=75&w=750 750w, /images/abc123-1000x1000.jpg/${vanityName}?auto=format&fit=max&q=75&w=1000 1000w`
+      )
+    })
+  })
+})
+
 describe("custom query string params", () => {
   it("supports valid query string params", () => {
     const { baseElement } = render(

--- a/src/SanityImage.tsx
+++ b/src/SanityImage.tsx
@@ -22,6 +22,7 @@ export const SanityImage = <C extends ElementType = "img">({
   width,
   height,
   mode = "contain",
+  vanityName,
 
   // Data for LQIP (preview image)
   preview,
@@ -79,6 +80,7 @@ export const SanityImage = <C extends ElementType = "img">({
     height,
     mode,
     queryParams,
+    vanityName,
   }
 
   const { src, ...outputDimensions } = buildSrc(srcParams)

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,12 @@ export type SanityImageProps = ImageQueryInputs & {
    * case, please open an issue and I'd be delighted to consider it.
    */
   queryParams?: DirectQueryParams
+  
+  /**
+   * Optional filename to append to the image URL. Sometimes useful for
+   * SEO purposes.
+   */
+  vanityName?: string
 }
 
 export type ImageWithPreviewProps<T extends React.ElementType> = {
@@ -173,7 +179,7 @@ export type ImageQueryInputs = {
   queryParams?: DirectQueryParams
 }
 
-export type ImageSrcInputs = ImageQueryInputs & { baseUrl: string }
+export type ImageSrcInputs = ImageQueryInputs & { baseUrl: string, vanityName?: string }
 
 export type ImageQueryParams = DirectQueryParams & {
   /**

--- a/src/urlBuilder.ts
+++ b/src/urlBuilder.ts
@@ -13,6 +13,7 @@ import type {
  */
 export const buildSrc = ({
   baseUrl,
+  vanityName,
   ...inputParams
 }: ImageSrcInputs): ComputedImageData => {
   const { metadata, ...queryParams } = buildQueryParams({
@@ -25,7 +26,9 @@ export const buildSrc = ({
     throw new Error("Missing image output metadata")
   }
 
-  const imageUrl = `${baseUrl}${imageIdToUrlPath(inputParams.id)}`
+  let imageUrl = `${baseUrl}${imageIdToUrlPath(inputParams.id)}`
+  
+  if (vanityName) imageUrl += `/${vanityName}`
 
   return {
     src: `${imageUrl}?${buildQueryString(queryParams)}`,
@@ -42,13 +45,16 @@ export const buildSrcSet = ({
   hotspot,
   crop,
   baseUrl,
+  vanityName,
   ...inputParams
 }: ImageSrcInputs): string[] => {
   // Determine base computed width
   const { w, h } = buildQueryParams({ id, mode, width, height, hotspot, crop })
 
   // URL of the image without any query parameters
-  const imageUrl = `${baseUrl}${imageIdToUrlPath(id)}`
+  let imageUrl = `${baseUrl}${imageIdToUrlPath(id)}`
+  
+  if (vanityName) imageUrl += `/${vanityName}`
 
   // Build srcset
   const srcSetEntries: string[] = dynamicMultipliers(w)


### PR DESCRIPTION
This PR adds support for vanity names, as referenced in the Sanity docs [here](https://www.sanity.io/docs/image-url#vanitynamefilename).

When passing in a `vanityName` prop, that string is appended to the URL before the query params.