### PR TITLE
Fix incorrect 'sharpen' parameter

### DIFF
--- a/packages/url-builder/src/types.ts
+++ b/packages/url-builder/src/types.ts
@@ -74,7 +74,7 @@ export type DirectQueryParams = {
   /**
    * Sharpen 0-100.
    */
-  sharpen?: number
+  sharp?: number
 }
 
 /**


### PR DESCRIPTION
It's called `sharp`, see https://www.sanity.io/docs/apis-and-sdks/image-urls#sharp-4a8148eeb5b3