### PR TITLE
Prevent "alt" and "loading" attributes from being set on the html element, when using as=source

### DIFF
--- a/src/SanityImage.test.tsx
+++ b/src/SanityImage.test.tsx
@@ -302,6 +302,37 @@ describe("svg source image", () => {
     expect(source?.getAttribute("src")).toBeNull()
     expect(source?.getAttribute("srcset")).toBe("/images/abc123-300x100.svg")
   })
+
+  it("omits alt and loading when used as source element", () => {
+    const svgId = "image-abc123-300x100-svg"
+
+    const { baseElement } = render(
+      <SanityImage
+        as="source"
+        id={svgId}
+        width={2000}
+        height={1000}
+        baseUrl={baseUrl}
+      />
+    )
+
+    const source = baseElement.querySelector("source")
+    expect(source?.getAttribute("alt")).toBeNull()
+    expect(source?.getAttribute("loading")).toBeNull()
+  })
+})
+
+describe("as source element", () => {
+  it("omits alt and loading attributes", () => {
+    const { baseElement } = render(
+      <SanityImage as="source" id={id} width={500} baseUrl={baseUrl} />
+    )
+
+    const source = baseElement.querySelector("source")
+    expect(source).toBeTruthy()
+    expect(source?.getAttribute("alt")).toBeNull()
+    expect(source?.getAttribute("loading")).toBeNull()
+  })
 })
 
 describe("custom query string params", () => {

--- a/src/SanityImage.tsx
+++ b/src/SanityImage.tsx
@@ -49,9 +49,10 @@ export const SanityImage = <T extends React.ElementType = "img">({
   const ImageComponent =
     preview && !isSvg ? ImageWithPreview : (component ?? "img")
 
+  const isSourceElement = component === "source"
+
   const componentProps: Record<string, unknown> = {
-    alt: rest.alt ?? "",
-    loading: rest.loading ?? "lazy",
+    ...(!isSourceElement && { alt: rest.alt ?? "", loading: rest.loading ?? "lazy" }),
     id: htmlId,
     ...rest,
   }
@@ -67,7 +68,7 @@ export const SanityImage = <T extends React.ElementType = "img">({
 
     // If this is a <source> element, we need to set the `srcSet` attribute and not
     // the `src` attribute, otherwise it will be ignored in <picture> elements.
-    if (component === "source") {
+    if (isSourceElement) {
       baseAttributes.srcSet = baseAttributes.src
       delete baseAttributes.src
     }


### PR DESCRIPTION
alt and loading are not supported by html spec: https://html.spec.whatwg.org/dev/embedded-content.html#the-source-element